### PR TITLE
Add date selection for new entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,6 @@
 1. 新增按月份檢視記錄功能(ChatGpt codex)
 2. 收支分類圖表依月份顯示(ChatGpt codex)
 3. 調整版型
+#### 20250607 調整功能
+1. 新增可指定日期記錄(ChatGpt codex)
 

--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
 </div>
 
 <form id="entryForm">
+    <input type="date" id="entryDate" required>
     <input type="text" id="desc" placeholder="項目描述" required>
     <input type="number" id="amount" placeholder="金額" required>
     <select id="type">
@@ -173,6 +174,7 @@
     const typeSelect = document.getElementById('type');
     const newCategoryTypeSelect = document.getElementById('categoryType');
     const categorySelect = document.getElementById('category');
+    const dateInput = document.getElementById('entryDate');
 
     // base64 encode/decode for simple obfuscation
     const encode = (str) => btoa(unescape(encodeURIComponent(str)));
@@ -386,7 +388,7 @@
         const amount = parseFloat(amountInput.value);
         const type = typeSelect.value;
         const category = categorySelect.value;
-        const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+        const date = dateInput.value || new Date().toISOString().slice(0, 10); // YYYY-MM-DD
 
         if (!desc || isNaN(amount)) return;
 
@@ -422,6 +424,7 @@
 
     // 載入
     document.getElementById('calendar').value = new Date().toISOString().slice(0, 7);
+    dateInput.value = new Date().toISOString().slice(0, 10);
     renderEntries();
 
     const defaultIncomeCategories = ['薪資', '投資', '其他'];


### PR DESCRIPTION
## Summary
- allow specifying a date when adding a record
- default the date input to the current day
- document new feature in README

## Testing
- `git log -2 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684267991acc8321be7b3fb073f28251